### PR TITLE
Implement single-page audio book player

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,25 @@
-import os
-import sys
+"""Main application module for Advanced Writing audio book site.
+
+This module defines the Flask application that serves the single-page
+interface for listening to the audio book. It exposes ``app`` for WSGI
+servers and the Flask CLI.
+"""
+
+from flask import Flask, render_template
+
+app = Flask(__name__)
 
 
-sys.path.insert(0, os.path.dirname(__file__))
+@app.route("/")
+def index() -> str:
+    """Render the main page of the audio book site.
+
+    Returns:
+        Rendered HTML for the index page.
+    """
+    book_title = "The Science of Prestige Television"
+    return render_template("index.html", book_title=book_title)
 
 
-def app(environ, start_response):
-    start_response('200 OK', [('Content-Type', 'text/plain')])
-    message = 'It works!\n'
-    version = 'Python v' + sys.version.split()[0] + '\n'
-    response = '\n'.join([message, version])
-    return [response.encode()]
+if __name__ == "__main__":  # pragma: no cover - convenience for local running
+    app.run(debug=True)

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1,0 +1,79 @@
+(function () {
+    const audio = document.getElementById('audioPlayer');
+    const chaptersUl = document.getElementById('chapters');
+    const pdfButton = document.getElementById('pdf-button');
+
+    pdfButton.addEventListener('click', () => {
+        window.open(pdfPath, '_blank');
+    });
+
+    function saveProgress() {
+        const data = {
+            src: audio.getAttribute('data-track') || '',
+            time: audio.currentTime || 0
+        };
+        document.cookie = 'audiobook=' + encodeURIComponent(JSON.stringify(data)) + ';path=/';
+    }
+
+    function loadProgress() {
+        const match = document.cookie.match(/(?:^|; )audiobook=([^;]*)/);
+        if (match) {
+            try {
+                const data = JSON.parse(decodeURIComponent(match[1]));
+                if (data.src) {
+                    setTrack(data.src, false);
+                    audio.currentTime = data.time || 0;
+                }
+            } catch (e) {
+                // ignore malformed cookie
+            }
+        }
+    }
+
+    function setTrack(src, autoplay = true) {
+        audio.pause();
+        audio.src = src;
+        audio.setAttribute('data-track', src);
+        audio.load();
+        if (autoplay) {
+            audio.play();
+        }
+        saveProgress();
+    }
+
+    audio.addEventListener('timeupdate', saveProgress);
+
+    fetch(jsonPath)
+        .then((r) => r.json())
+        .then((data) => {
+            data.chapters.forEach((chapter) => {
+                const li = document.createElement('li');
+                li.textContent = chapter.title;
+                li.dataset.chapterId = chapter.id;
+                chaptersUl.appendChild(li);
+
+                if (chapter.id === 0) {
+                    li.addEventListener('click', () => {
+                        setTrack('/static/audio/0.mp3');
+                    });
+                } else {
+                    const sections = document.createElement('ul');
+                    sections.className = 'section-list';
+                    chapter.sections.forEach((section) => {
+                        const secLi = document.createElement('li');
+                        secLi.textContent = section.title;
+                        secLi.addEventListener('click', (evt) => {
+                            evt.stopPropagation();
+                            setTrack(`/static/audio/${chapter.id}-${section.id}.mp3`);
+                        });
+                        sections.appendChild(secLi);
+                    });
+                    li.appendChild(sections);
+                    li.addEventListener('click', () => {
+                        sections.style.display = sections.style.display === 'none' ? 'block' : 'none';
+                    });
+                }
+            });
+            loadProgress();
+        });
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ book_title }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #chapters { list-style-type: none; padding: 0; }
+        #chapters > li { margin: 5px 0; cursor: pointer; }
+        .section-list { list-style-type: none; padding-left: 20px; display: none; }
+        .section-list li { cursor: pointer; margin: 3px 0; }
+        button { margin-bottom: 10px; }
+    </style>
+</head>
+<body>
+    <h1>{{ book_title }}</h1>
+    <button id="pdf-button">Open PDF</button>
+    <br>
+    <audio id="audioPlayer" controls></audio>
+    <ul id="chapters"></ul>
+    <script>
+        const jsonPath = "{{ url_for('static', filename='The Science of Prestige Television.json') }}";
+        const pdfPath = "{{ url_for('static', filename='The Science of Prestige Television.pdf') }}";
+    </script>
+    <script src="{{ url_for('static', filename='js/player.js') }}"></script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,15 @@
+"""Tests for the Advanced Writing Flask application."""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from main import app
+
+
+def test_index_route() -> None:
+    """The index route should return the main page with the book title."""
+    client = app.test_client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"The Science of Prestige Television" in response.data


### PR DESCRIPTION
## Summary
- Convert main module into a Flask app serving a single-page audio book interface.
- Add HTML template and JavaScript for chapter/section navigation, PDF link, and cookie-based progress resume.
- Introduce a basic pytest verifying the index route returns the book title.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68960a1574548324b7ae8b7478596bbc