### PR TITLE
Render chapter list server side and enhance mobile layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@ This repository hosts a one-page [Flask](https://flask.palletsprojects.com/) app
 
 ## Features
 
-* **Single-page audio player** – The site loads once and uses Ajax to retrieve chapter and section information without requiring full page reloads.
+* **Single-page audio player** – The site loads once and presents a hierarchical chapter list; selecting a section begins playback without a full page reload.
 * **Hierarchical chapter list** – Chapter titles are displayed in a left-aligned list. Selecting a chapter reveals its sections; selecting a section begins playback.
     * Chapter `0` is a special case with only one section; clicking the chapter immediately plays `0.mp3`.
 * **Automatic audio switching** – Starting a new track stops the currently playing audio before the next one begins.
 * **Progress persistence** – Cookies remember the last track and timestamp so users can continue where they left off after closing or reloading the page.
 * **Read-along PDF** – A button at the top opens the book PDF in a new window so the user can read along with the audio.
+* **Mobile friendly** – A responsive layout and scalable controls make the site easy to use on phones and tablets.
 
 ## Data sources
 
 * `static/` contains the book JSON file and the PDF.
 * `static/audio/` holds the audio files. Naming follows the pattern `<chapter>-<section>.mp3` except for chapter `0`, which is stored as `0.mp3`.
 
-The JSON file maps chapter and section IDs to titles and is used by the front end to build the playlist dynamically.
+The JSON file maps chapter and section IDs to titles. The server reads this file to render the chapter list.
 
 ## Running locally
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,9 @@ interface for listening to the audio book. It exposes ``app`` for WSGI
 servers and the Flask CLI.
 """
 
+from pathlib import Path
+import json
+
 from flask import Flask, render_template
 
 app = Flask(__name__)
@@ -18,7 +21,10 @@ def index() -> str:
         Rendered HTML for the index page.
     """
     book_title = "The Science of Prestige Television"
-    return render_template("index.html", book_title=book_title)
+    json_path = Path(app.static_folder) / "The Science of Prestige Television.json"
+    with json_path.open(encoding="utf-8") as handle:
+        chapters = json.load(handle).get("chapters", [])
+    return render_template("index.html", book_title=book_title, chapters=chapters)
 
 
 if __name__ == "__main__":  # pragma: no cover - convenience for local running

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1,6 +1,5 @@
 (function () {
     const audio = document.getElementById('audioPlayer');
-    const chaptersUl = document.getElementById('chapters');
     const pdfButton = document.getElementById('pdf-button');
 
     pdfButton.addEventListener('click', () => {
@@ -43,37 +42,21 @@
 
     audio.addEventListener('timeupdate', saveProgress);
 
-    fetch(jsonPath)
-        .then((r) => r.json())
-        .then((data) => {
-            data.chapters.forEach((chapter) => {
-                const li = document.createElement('li');
-                li.textContent = chapter.title;
-                li.dataset.chapterId = chapter.id;
-                chaptersUl.appendChild(li);
-
-                if (chapter.id === 0) {
-                    li.addEventListener('click', () => {
-                        setTrack('/static/audio/0.mp3');
-                    });
-                } else {
-                    const sections = document.createElement('ul');
-                    sections.className = 'section-list';
-                    chapter.sections.forEach((section) => {
-                        const secLi = document.createElement('li');
-                        secLi.textContent = section.title;
-                        secLi.addEventListener('click', (evt) => {
-                            evt.stopPropagation();
-                            setTrack(`/static/audio/${chapter.id}-${section.id}.mp3`);
-                        });
-                        sections.appendChild(secLi);
-                    });
-                    li.appendChild(sections);
-                    li.addEventListener('click', () => {
-                        sections.style.display = sections.style.display === 'none' ? 'block' : 'none';
-                    });
-                }
-            });
-            loadProgress();
+    document.querySelectorAll('[data-audio]').forEach((el) => {
+        el.addEventListener('click', (evt) => {
+            evt.stopPropagation();
+            setTrack(el.getAttribute('data-audio'));
         });
+    });
+
+    document.querySelectorAll('#chapters > li').forEach((chapter) => {
+        const sections = chapter.querySelector('.section-list');
+        if (sections) {
+            chapter.addEventListener('click', () => {
+                sections.style.display = sections.style.display === 'none' ? 'block' : 'none';
+            });
+        }
+    });
+
+    loadProgress();
 })();

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,24 +2,64 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ book_title }}</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        #chapters { list-style-type: none; padding: 0; }
-        #chapters > li { margin: 5px 0; cursor: pointer; }
-        .section-list { list-style-type: none; padding-left: 20px; display: none; }
-        .section-list li { cursor: pointer; margin: 3px 0; }
-        button { margin-bottom: 10px; }
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            max-width: 700px;
+        }
+        audio,
+        button {
+            width: 100%;
+            max-width: 100%;
+        }
+        #chapters {
+            list-style: none;
+            padding: 0;
+        }
+        #chapters > li {
+            margin: 5px 0;
+            cursor: pointer;
+        }
+        .section-list {
+            list-style: none;
+            padding-left: 20px;
+            display: none;
+        }
+        .section-list li {
+            cursor: pointer;
+            margin: 3px 0;
+        }
+        @media (max-width: 600px) {
+            body {
+                margin: 10px;
+            }
+        }
     </style>
 </head>
 <body>
     <h1>{{ book_title }}</h1>
     <button id="pdf-button">Open PDF</button>
-    <br>
     <audio id="audioPlayer" controls></audio>
-    <ul id="chapters"></ul>
+    <ul id="chapters">
+        {% for chapter in chapters %}
+        {% if chapter.id == 0 %}
+        <li data-audio="/static/audio/0.mp3">{{ chapter.title }}</li>
+        {% else %}
+        <li>
+            {{ chapter.title }}
+            <ul class="section-list">
+                {% for section in chapter.sections %}
+                <li data-audio="/static/audio/{{ chapter.id }}-{{ section.id }}.mp3">{{ section.title }}</li>
+                {% endfor %}
+            </ul>
+        </li>
+        {% endif %}
+        {% endfor %}
+    </ul>
     <script>
-        const jsonPath = "{{ url_for('static', filename='The Science of Prestige Television.json') }}";
         const pdfPath = "{{ url_for('static', filename='The Science of Prestige Television.pdf') }}";
     </script>
     <script src="{{ url_for('static', filename='js/player.js') }}"></script>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,8 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from main import app
+import json
+from pathlib import Path
 
 
 def test_index_route() -> None:
@@ -13,3 +15,13 @@ def test_index_route() -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert b"The Science of Prestige Television" in response.data
+
+
+def test_chapter_list_rendered() -> None:
+    """Chapter titles from the JSON file should appear in the response."""
+    client = app.test_client()
+    response = client.get("/")
+    json_path = Path(app.static_folder) / "The Science of Prestige Television.json"
+    with json_path.open(encoding="utf-8") as handle:
+        first_title = json.load(handle)["chapters"][0]["title"]
+    assert first_title.encode() in response.data


### PR DESCRIPTION
## Summary
- Render chapter and section metadata server side to ensure the playlist is always visible
- Revamp JavaScript to hook into pre-rendered list and keep playback progress
- Add responsive layout with viewport tag and scalable controls for better mobile support
- Document new behavior and add test confirming chapter titles are rendered

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68960f6912e08324ad235d3b09538aa3