### PR TITLE
Handle podcast fetch path robustly

### DIFF
--- a/static/js/player.js
+++ b/static/js/player.js
@@ -115,8 +115,8 @@
     });
 
     function loadPodcasts() {
-        fetch('/podcasts')
-            .then((resp) => resp.json())
+        fetch(podcastsUrl)
+            .then((resp) => (resp.ok ? resp.json() : []))
             .then((items) => {
                 const list = document.getElementById('podcastList');
                 items.forEach((item) => {
@@ -125,7 +125,8 @@
                     li.setAttribute('data-audio', item.src);
                     list.appendChild(li);
                 });
-            });
+            })
+            .catch(() => {});
     }
 
     loadPodcasts();

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,6 +111,7 @@
             'static',
             filename='The Science of Prestige Television.pdf'
         ) }}";
+        const podcastsUrl = "{{ url_for('podcasts') }}";
     </script>
     <script src="{{ url_for('static', filename='js/player.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- Obtain podcast endpoint URL from Flask template
- Fetch podcast list using provided URL with simple error handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68993ec17a148324af373f66006d9ecc