### PR TITLE
Fix PDF link and style podcast list

### DIFF
--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1,11 +1,6 @@
 (function () {
     const audio = document.getElementById('audioPlayer');
-    const pdfButton = document.getElementById('pdf-button');
     let currentTrackEl = null;
-
-    pdfButton.addEventListener('click', () => {
-        window.open(pdfPath, '_blank');
-    });
 
     function saveProgress() {
         const data = {
@@ -125,6 +120,7 @@
                     const li = document.createElement('li');
                     li.textContent = item.title;
                     li.setAttribute('data-audio', item.src);
+                    li.classList.add('list-group-item');
                     list.appendChild(li);
                 });
             })

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,12 +27,15 @@
                 Podcast
             </button>
         </div>
-        <button
+        <a
             id="pdf-button"
             class="btn btn-secondary btn-lg w-100 mb-3"
+            href="{{ url_for('static', filename='The Science of Prestige Television.pdf') }}"
+            target="_blank"
+            rel="noopener noreferrer"
         >
             Open PDF
-        </button>
+        </a>
         <audio id="audioPlayer" controls class="w-100 mb-3"></audio>
         <div id="audiobook" class="tab-content">
             <ul id="chapters" class="list-group text-start">
@@ -70,7 +73,6 @@
         </div>
     </div>
     <script>
-        const pdfPath = "{{ url_for('static', filename='The Science of Prestige Television.pdf') }}";
         const podcastsUrl = "{{ url_for('podcasts') }}";
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- Link PDF button directly to the bundled PDF file with a standard anchor tag
- Style podcast list items with Bootstrap's `list-group-item` class so they match the audiobook tab

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68994280af1c8324a4feb69f4d4e3681