### PR TITLE
Fix PDF button with dedicated route

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ servers and the Flask CLI.
 from pathlib import Path
 import json
 
-from flask import Flask, Response, jsonify, render_template, url_for
+from flask import Flask, Response, jsonify, render_template, url_for, send_from_directory
 
 app = Flask(__name__)
 
@@ -25,6 +25,14 @@ def index() -> str:
     with json_path.open(encoding="utf-8") as handle:
         chapters = json.load(handle).get("chapters", [])
     return render_template("index.html", book_title=book_title, chapters=chapters)
+
+
+@app.route("/pdf")
+def pdf() -> Response:
+    """Serve the full book PDF file."""
+    return send_from_directory(
+        app.static_folder, "The Science of Prestige Television.pdf"
+    )
 
 
 @app.route("/podcasts")

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
         <a
             id="pdf-button"
             class="btn btn-secondary btn-lg w-100 mb-3"
-            href="{{ url_for('static', filename='The Science of Prestige Television.pdf') }}"
+            href="{{ url_for('pdf') }}"
             target="_blank"
             rel="noopener noreferrer"
         >

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -37,3 +37,11 @@ def test_podcast_route() -> None:
     assert ids == list(range(1, 8))
     for item in data:
         assert item["src"] == f"/static/podcast/{item['id']}.mp3"
+
+
+def test_pdf_route() -> None:
+    """The PDF route should serve the book PDF file."""
+    client = app.test_client()
+    response = client.get("/pdf")
+    assert response.status_code == 200
+    assert response.mimetype == "application/pdf"


### PR DESCRIPTION
## Summary
- Add new `/pdf` route to serve the book PDF reliably
- Link PDF button to the new route
- Test PDF endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899446a3270832496e7963db77bf4a3