### PR TITLE
style: update typography and color scheme

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,14 +1,32 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap');
 
 :root {
-    --bs-primary: #4a90e2;
+    --color-bg: #07212F;
+    --color-bg-variant1: #071F2D;
+    --color-bg-variant2: #082230;
+    --color-accent: #327C85;
+    --color-accent-dark: #083649;
+    --color-accent-muted: #1D5A67;
+    --bs-primary: var(--color-accent);
+    --bs-secondary: var(--color-accent-dark);
 }
 
 body {
-    background-color: #f8f9fa;
-    color: #212529;
-    font-family: 'Roboto', sans-serif;
+    background-color: var(--color-bg);
+    color: #ffffff;
+    font-family: 'Inter', sans-serif;
     text-align: center;
+}
+
+h1 {
+    font-family: 'Bebas Neue', sans-serif;
+    text-transform: uppercase;
+    color: var(--color-accent);
+}
+
+.subtitle {
+    font-family: 'Inter', sans-serif;
+    color: var(--color-accent-muted);
 }
 
 ul {
@@ -23,12 +41,38 @@ ul {
     margin-right: 0.5rem;
 }
 
+.btn-primary,
+.btn-outline-primary {
+    --bs-btn-bg: var(--color-accent);
+    --bs-btn-border-color: var(--color-accent);
+    --bs-btn-hover-bg: var(--color-accent-dark);
+    --bs-btn-hover-border-color: var(--color-accent-dark);
+}
+
+.btn-outline-primary {
+    --bs-btn-color: var(--color-accent);
+    --bs-btn-hover-color: #ffffff;
+}
+
+.btn-secondary {
+    --bs-btn-bg: var(--color-accent-dark);
+    --bs-btn-border-color: var(--color-accent-dark);
+    --bs-btn-hover-bg: var(--color-accent-muted);
+    --bs-btn-hover-border-color: var(--color-accent-muted);
+}
+
 .section-list {
     display: none;
     margin-top: 0.5rem;
 }
 
+.list-group-item {
+    background-color: var(--color-bg-variant1);
+    color: #ffffff;
+    border-color: var(--color-accent-dark);
+}
+
 .playing {
-    background-color: #e7f1ff;
-    border-color: var(--bs-primary);
+    background-color: var(--color-bg-variant2);
+    border-color: var(--color-accent);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     >
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
-<body class="bg-light text-center">
+<body class="text-center">
     <div class="container py-4">
         <h1 class="mb-4">{{ book_title }}</h1>
         <div id="tabs" class="mb-3">


### PR DESCRIPTION
## Summary
- Integrate new midnight blue/teal color palette with CSS variables
- Switch typography to Bebas Neue for titles and Inter for body text
- Remove Bootstrap's light background in favor of custom theming

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689948cb721c8324bf3cab19baa800ed