### PR TITLE
Use mobile font stack for desktop hero title

### DIFF
--- a/static/images/web_hero_blueprint.svg
+++ b/static/images/web_hero_blueprint.svg
@@ -12,9 +12,10 @@
       }
 
       .st7 {
-        font-family: BebasNeueBold, 'Bebas Neue';
+        font-family: 'League Spartan', 'Bebas Neue', 'Oswald', system-ui, -apple-system, sans-serif;
         font-size: 112px;
-        letter-spacing: 0em;
+        font-weight: 800;
+        letter-spacing: 0.5px;
       }
 
       .st7, .st8, .st9, .st3, .st10, .st11 {


### PR DESCRIPTION
## Summary
- Align desktop hero title font family with mobile version for consistent sans-serif styling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68996388472c8324a9b3d3fae431b3e8