### PR TITLE
Use podcast title and subtitle for podcast list

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,15 +41,21 @@ def podcasts() -> Response:
 
     MP3 files are named using the chapter ID (e.g. ``1.mp3``). The response
     is a JSON array with objects containing ``id`` (chapter number),
-    ``title`` and ``src`` URL for each podcast file. Chapter ``0`` is
-    excluded.
+    ``title``, ``subtitle`` and ``src`` URL for each podcast file. Chapter
+    ``0`` is excluded.
 
     Returns:
         JSON list describing available podcast audio files.
     """
     json_path = Path(app.static_folder) / "The Science of Prestige Television.json"
     with json_path.open(encoding="utf-8") as handle:
-        chapters = {int(c["id"]): c["title"] for c in json.load(handle)["chapters"]}
+        chapters = {
+            int(c["id"]): (
+                c.get("podcast_title") or c["title"],
+                c.get("podcast_subtitle", ""),
+            )
+            for c in json.load(handle)["chapters"]
+        }
     podcast_dir = Path(app.static_folder) / "podcast"
     files = []
     for path in sorted(podcast_dir.glob("*.mp3")):
@@ -59,10 +65,12 @@ def podcasts() -> Response:
             continue
         if chap_id == 0:
             continue
+        title, subtitle = chapters.get(chap_id, (f"Chapter {chap_id}", ""))
         files.append(
             {
                 "id": chap_id,
-                "title": chapters.get(chap_id, f"Chapter {chap_id}"),
+                "title": title,
+                "subtitle": subtitle,
                 "src": url_for("static", filename=f"podcast/{path.name}"),
             }
         )

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -116,9 +116,19 @@
                 const list = document.getElementById('podcastList');
                 items.forEach((item) => {
                     const li = document.createElement('li');
-                    li.textContent = item.title;
                     li.setAttribute('data-audio', item.src);
                     li.classList.add('list-group-item');
+
+                    const title = document.createElement('strong');
+                    title.textContent = item.title;
+                    li.appendChild(title);
+
+                    if (item.subtitle) {
+                        const subtitle = document.createElement('div');
+                        subtitle.textContent = item.subtitle;
+                        li.appendChild(subtitle);
+                    }
+
                     list.appendChild(li);
                 });
             })

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -39,6 +39,22 @@ def test_podcast_route() -> None:
         assert item["src"] == f"/static/podcast/{item['id']}.mp3"
 
 
+def test_podcast_titles_subtitles() -> None:
+    """Podcast items should include titles and subtitles from the JSON."""
+    client = app.test_client()
+    response = client.get("/podcasts")
+    data = response.get_json()
+    json_path = Path(app.static_folder) / "The Science of Prestige Television.json"
+    with json_path.open(encoding="utf-8") as handle:
+        chapters = {int(c["id"]): c for c in json.load(handle)["chapters"]}
+    for item in data:
+        chapter = chapters[item["id"]]
+        expected_title = chapter.get("podcast_title") or chapter["title"]
+        expected_subtitle = chapter.get("podcast_subtitle", "")
+        assert item["title"] == expected_title
+        assert item["subtitle"] == expected_subtitle
+
+
 def test_pdf_route() -> None:
     """The PDF route should serve the book PDF file."""
     client = app.test_client()


### PR DESCRIPTION
## Summary
- Send podcast titles and subtitles from the JSON to the frontend
- Render podcast titles in bold with subtitles beneath them
- Test that podcast metadata includes title and subtitle

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689973527ba48324adceb870e484a6f4