### PR TITLE
Handle new podcast files automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This repository hosts a one-page [Flask](https://flask.palletsprojects.com/) app
 * `static/` contains the book JSON file and the PDF.
 * `static/audio/` holds the audio files. Naming follows the pattern `<chapter>-<section>.mp3` except for chapter `0`, which is stored as `0.mp3`.
 * `static/podcast/` holds one podcast episode per chapter, named
-  `<chapter>-<chapter-title>.mp3` (for example,
-  `1-Series-Engines-and-Premise-Design.mp3`).
+  `<chapter>.mp3` (for example,
+  `1.mp3`).
 
 The JSON file maps chapter and section IDs to titles. The server reads this file to render the chapter list.
 

--- a/static/The Science of Prestige Television.json
+++ b/static/The Science of Prestige Television.json
@@ -209,10 +209,11 @@
 				}
 			]
 		},
-		{
-			"id": 8,
-			"podcast_title": "The Blueprint of Binge-Watching",
-			"podcast_subtitle": "How TV Pilots Hook You for a Hundred Episodes",
-		}
-	]
+                {
+                        "id": 8,
+                        "title": "The Blueprint of Binge-Watching",
+                        "podcast_title": "The Blueprint of Binge-Watching",
+                        "podcast_subtitle": "How TV Pilots Hook You for a Hundred Episodes"
+                }
+        ]
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,7 +34,11 @@ def test_podcast_route() -> None:
     data = response.get_json()
     assert isinstance(data, list)
     ids = [item["id"] for item in data]
-    assert ids == list(range(1, 8))
+    podcast_dir = Path(app.static_folder) / "podcast"
+    expected_ids = sorted(
+        int(p.stem) for p in podcast_dir.glob("*.mp3") if p.stem.isdigit()
+    )
+    assert ids == expected_ids
     for item in data:
         assert item["src"] == f"/static/podcast/{item['id']}.mp3"
 


### PR DESCRIPTION
## Summary
- fix trailing comma and add title for the new podcast entry so JSON remains valid
- compute expected podcast IDs dynamically in tests
- document podcast naming scheme

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689e8301a1348324a0fb0830d793fc36